### PR TITLE
fix: declare "types" in package.json "exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "types",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./index.mjs",
       "require": "./index.js"
     }


### PR DESCRIPTION
When importing vite-plugin-target in a project with `"moduleResolution": "Bundler"` or `"moduleResolution": "NodeNext"`, typescript cannot resolve the .d.ts provided by vite-plugin-target with the following error:

```
error TS7016: Could not find a declaration file for module 'vite-plugin-target'. '<...>/node_modules/.pnpm/vite-plugin-target@0.1.1/node_modules/vite-plugin-target/index.mjs' implicitly has an 'any' type.
  There are types at '<...>/node_modules/vite-plugin-target/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vite-plugin-target' library may need to update its package.json or typings.
```

Despite declaring root-level "types" in package.json, it should also be declared in package.json "exports".