### PR TITLE
fix: exports types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "vite-plugin-target",
   "version": "0.1.1",
   "description": "Make Vite support Electron, Node.js, etc.",
-  "main": "index.js",
-  "types": "types",
+  "main": "./index.js",
+  "module": "./index.mjs",
+  "types": "./types/index.d.ts",
   "exports": {
     ".": {
       "import": "./index.mjs",
-      "require": "./index.js"
+      "require": "./index.js",
+      "types": "./types/index.d.ts"
     }
   },
   "repository": "https://github.com/vite-plugin/vite-plugin-target.git",


### PR DESCRIPTION
fix: vscode dts error

```ts
Could not find a declaration file for module 'vite-plugin-target'. 'D:/Work/tomjs/utils/node_modules/.pnpm/vite-plugin-target@0.1.1/node_modules/vite-plugin-target/index.mjs' implicitly has an 'any' type.
  There are types at 'd:/Work/tomjs/utils/node_modules/vite-plugin-target/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vite-plugin-target' library may need to update its package.json or typings.ts(7016)
```